### PR TITLE
Fix/eslintrc empty rules

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,5 +1,5 @@
 # YAML allows comments.
 root: true
 extends: [fullstack, prettier, prettier/react]
-rules:
-    # semi: [1, never]
+# rules:
+#     semi: [1, never]

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,9 @@
+_Write your issue description here_
+
+---
+
 For bugs, please include the following:
 
 *   What is the expected behavior?
 *   What is the actual behavior?
 *   What steps reproduce the behavior?
-
----
-
-_Issue description here…_

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
+_Write your PR notes here_
+
+---
+
 ### Assignee Tasks
 
 *   [ ] added unit tests
 *   [ ] written relevant docs
 *   [ ] referenced any relevant issues
-
----
-
-_Your PR Notes Here_


### PR DESCRIPTION
Fixes an issue wherein the eslintrc wouldn't be parsed because `rules` was an empty object.

---

### Assignee Tasks

*   [x] added unit tests (N/A)
*   [x] written relevant docs (N/A)
*   [x] referenced any relevant issues (N/A)
